### PR TITLE
synchronize! not-cuda-aware bug fix

### DIFF
--- a/src/synchronize.jl
+++ b/src/synchronize.jl
@@ -1,7 +1,10 @@
 """
     synchronize!(x; root_rank::Integer=0)
 
-Synchronize `x` across all processes. Note: this function is not in-place for CuArrays when MPI is not CUDA aware.
+Synchronize `x` across all processes.
+
+!!! note
+    this function is not in-place for CuArrays when MPI is not CUDA aware.
 """
 function synchronize!(ps::Union{NamedTuple, Tuple}; root_rank::Integer=0)
   length(ps) == 0 && return ps

--- a/src/synchronize.jl
+++ b/src/synchronize.jl
@@ -1,7 +1,7 @@
 """
     synchronize!(x; root_rank::Integer=0)
 
-Synchronize `x` across all processes.
+Synchronize `x` across all processes. Note: this function is not in-place for CuArrays when MPI is not CUDA aware.
 """
 function synchronize!(ps::Union{NamedTuple, Tuple}; root_rank::Integer=0)
   length(ps) == 0 && return ps
@@ -9,8 +9,7 @@ function synchronize!(ps::Union{NamedTuple, Tuple}; root_rank::Integer=0)
 end
 
 function synchronize!(x::AbstractArray{T}; root_rank::Integer=0) where {T <: Number}
-  bcast!(x, root_rank, MPI.COMM_WORLD)
-  return x
+  return bcast!(x, root_rank, MPI.COMM_WORLD)
 end
 
 # Ideally these things should be Tuples and not arrays


### PR DESCRIPTION
The functions in `src/mpi_extentions` are not in-place when MPI is not CUDA aware, despite the convention of being prefixed with `!`, as the gpu<-> cpu conversion does not keep the reference. This causes `synchronize!` to fail silently for CuArrays (`src/synchronize.jl` line 11) as `bcast!` is incorrectly treated as being inplace. This can be fixed with simply returning the result of `bcast!`. A line in the docstring is of `synchronize` to make users aware of this fact.
